### PR TITLE
Refactor nonce creation

### DIFF
--- a/goincheck.go
+++ b/goincheck.go
@@ -354,7 +354,7 @@ func encodeBody(in interface{}) ([]byte, error) {
 }
 
 func getHeaders(key, secret, uri, body string) map[string]string {
-	currentTime := time.Now().UTC().Unix()
+	currentTime := time.Now().Unix()
 	nonce := strconv.FormatInt(currentTime, 10)
 	message := nonce + uri + body
 	signature := calcHmac256(message, secret)

--- a/goincheck.go
+++ b/goincheck.go
@@ -355,7 +355,7 @@ func encodeBody(in interface{}) ([]byte, error) {
 
 func getHeaders(key, secret, uri, body string) map[string]string {
 	currentTime := time.Now().UTC().Unix()
-	nonce := strconv.Itoa(int(currentTime))
+	nonce := strconv.FormatInt(currentTime, 10)
 	message := nonce + uri + body
 	signature := calcHmac256(message, secret)
 	return map[string]string{


### PR DESCRIPTION
* int64 を string に変換するのに `strconv.FormatInt` を使用すると int へのキャストが不要
* 時刻からUNIXタイムへの変換にロケーションの設定は不要

と思いましたがいかがでしょうか？